### PR TITLE
chore: use nuxi cli for typechecking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,11 +27,13 @@
         "nuxt-svgo": "^1.1.0",
         "playwright": "^1.28.1",
         "prisma": "^4.7.1",
+        "typescript": "^4.9.4",
         "unplugin-auto-import": "^0.12.1",
         "unplugin-vue-components": "^0.22.12",
         "uuid": "^9.0.0",
         "vite-svg-loader": "^3.6.0",
-        "vitest": "^0.25.7"
+        "vitest": "^0.25.7",
+        "vue-tsc": "^1.0.16"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2225,6 +2227,82 @@
         "sirv": "^2.0.2"
       }
     },
+    "node_modules/@volar/language-core": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.0.16.tgz",
+      "integrity": "sha512-IGnOxWTs4DZ81TDcmxBAkCBxs97hUblwcjpBsTx/pOGGaSSDQRJPn0wL8NYTybEObU0i7lhEpKZ+0vJfdIy1Kg==",
+      "dev": true,
+      "dependencies": {
+        "@volar/source-map": "1.0.16",
+        "@vue/reactivity": "^3.2.45",
+        "muggle-string": "^0.1.0"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.0.16.tgz",
+      "integrity": "sha512-PKjzmQcg8QOGC/1V9tmGh2jcy6bKLhkW5bGidElSr83iDbCzLvldt2/La/QlDxaRCHYLT0MeyuGJBZIChB1dYQ==",
+      "dev": true,
+      "dependencies": {
+        "muggle-string": "^0.1.0"
+      }
+    },
+    "node_modules/@volar/typescript": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.0.16.tgz",
+      "integrity": "sha512-Yov+n4oO3iYnuMt9QJAFpJabfTRCzc7KvjlAwBaSuZy+Gc/f9611MgtqAh5/SIGmltFN8dXn1Ijno8ro8I4lyw==",
+      "dev": true,
+      "dependencies": {
+        "@volar/language-core": "1.0.16"
+      }
+    },
+    "node_modules/@volar/vue-language-core": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.0.16.tgz",
+      "integrity": "sha512-sQ/aW1Vuiyy4OQuh2lthyYicruM3qh9VSk/aDh8/bFvM8GoohHZqVpMN3LYldEJ9eT/rN6u4xmYP54vc/EjX4Q==",
+      "dev": true,
+      "dependencies": {
+        "@volar/language-core": "1.0.16",
+        "@volar/source-map": "1.0.16",
+        "@vue/compiler-dom": "^3.2.45",
+        "@vue/compiler-sfc": "^3.2.45",
+        "@vue/reactivity": "^3.2.45",
+        "@vue/shared": "^3.2.45",
+        "minimatch": "^5.1.1",
+        "vue-template-compiler": "^2.7.14"
+      }
+    },
+    "node_modules/@volar/vue-language-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@volar/vue-language-core/node_modules/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@volar/vue-typescript": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.0.16.tgz",
+      "integrity": "sha512-M018Ulg/o2FVktAdlr5b/z4K69bYzekxNUA1o39y5Ur6CObc/o+5eDCCS7gIYijWnx9iNKkSQpWWWblJFv7kHQ==",
+      "dev": true,
+      "dependencies": {
+        "@volar/typescript": "1.0.16",
+        "@volar/vue-language-core": "1.0.16"
+      }
+    },
     "node_modules/@vue/babel-helper-vue-transform-on": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.0.2.tgz",
@@ -4371,6 +4449,12 @@
       "version": "1.11.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
       "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
+      "dev": true
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
       "dev": true
     },
     "node_modules/debug": {
@@ -6884,6 +6968,15 @@
       "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
       "dev": true
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "11.7.0",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.7.0.tgz",
@@ -8736,6 +8829,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/muggle-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.1.0.tgz",
+      "integrity": "sha512-Tr1knR3d2mKvvWthlk7202rywKbiOm4rVFLsfAaSIhJ6dt9o47W4S+JMtWhd/PW9Wrdew2/S2fSvhz3E2gkfEg==",
       "dev": true
     },
     "node_modules/mute-stream": {
@@ -12793,7 +12892,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13956,6 +14054,32 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/vue-template-compiler": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
+      "dev": true,
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.0.16.tgz",
+      "integrity": "sha512-yZaiJBbcKR1rSLhiF9KryAFH7R63po+N/invr2EAHGXxMzZksE5j1zyQKvrYiqK47ZHLAlCR+re/PHqWp/UzTg==",
+      "dev": true,
+      "dependencies": {
+        "@volar/vue-language-core": "1.0.16",
+        "@volar/vue-typescript": "1.0.16"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": "*"
       }
     },
     "node_modules/vueuc": {
@@ -16109,6 +16233,81 @@
         "sirv": "^2.0.2"
       }
     },
+    "@volar/language-core": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.0.16.tgz",
+      "integrity": "sha512-IGnOxWTs4DZ81TDcmxBAkCBxs97hUblwcjpBsTx/pOGGaSSDQRJPn0wL8NYTybEObU0i7lhEpKZ+0vJfdIy1Kg==",
+      "dev": true,
+      "requires": {
+        "@volar/source-map": "1.0.16",
+        "@vue/reactivity": "^3.2.45",
+        "muggle-string": "^0.1.0"
+      }
+    },
+    "@volar/source-map": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.0.16.tgz",
+      "integrity": "sha512-PKjzmQcg8QOGC/1V9tmGh2jcy6bKLhkW5bGidElSr83iDbCzLvldt2/La/QlDxaRCHYLT0MeyuGJBZIChB1dYQ==",
+      "dev": true,
+      "requires": {
+        "muggle-string": "^0.1.0"
+      }
+    },
+    "@volar/typescript": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.0.16.tgz",
+      "integrity": "sha512-Yov+n4oO3iYnuMt9QJAFpJabfTRCzc7KvjlAwBaSuZy+Gc/f9611MgtqAh5/SIGmltFN8dXn1Ijno8ro8I4lyw==",
+      "dev": true,
+      "requires": {
+        "@volar/language-core": "1.0.16"
+      }
+    },
+    "@volar/vue-language-core": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.0.16.tgz",
+      "integrity": "sha512-sQ/aW1Vuiyy4OQuh2lthyYicruM3qh9VSk/aDh8/bFvM8GoohHZqVpMN3LYldEJ9eT/rN6u4xmYP54vc/EjX4Q==",
+      "dev": true,
+      "requires": {
+        "@volar/language-core": "1.0.16",
+        "@volar/source-map": "1.0.16",
+        "@vue/compiler-dom": "^3.2.45",
+        "@vue/compiler-sfc": "^3.2.45",
+        "@vue/reactivity": "^3.2.45",
+        "@vue/shared": "^3.2.45",
+        "minimatch": "^5.1.1",
+        "vue-template-compiler": "^2.7.14"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@volar/vue-typescript": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.0.16.tgz",
+      "integrity": "sha512-M018Ulg/o2FVktAdlr5b/z4K69bYzekxNUA1o39y5Ur6CObc/o+5eDCCS7gIYijWnx9iNKkSQpWWWblJFv7kHQ==",
+      "dev": true,
+      "requires": {
+        "@volar/typescript": "1.0.16",
+        "@volar/vue-language-core": "1.0.16"
+      }
+    },
     "@vue/babel-helper-vue-transform-on": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.0.2.tgz",
@@ -17773,6 +17972,12 @@
       "version": "1.11.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
       "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
+      "dev": true
+    },
+    "de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
       "dev": true
     },
     "debug": {
@@ -19553,6 +19758,12 @@
       "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
       "dev": true
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
     "highlight.js": {
       "version": "11.7.0",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.7.0.tgz",
@@ -20962,6 +21173,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "muggle-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.1.0.tgz",
+      "integrity": "sha512-Tr1knR3d2mKvvWthlk7202rywKbiOm4rVFLsfAaSIhJ6dt9o47W4S+JMtWhd/PW9Wrdew2/S2fSvhz3E2gkfEg==",
       "dev": true
     },
     "mute-stream": {
@@ -23904,8 +24121,7 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "ufo": {
       "version": "1.0.1",
@@ -24756,6 +24972,26 @@
             "util.promisify": "~1.0.0"
           }
         }
+      }
+    },
+    "vue-template-compiler": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
+      "dev": true,
+      "requires": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "vue-tsc": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.0.16.tgz",
+      "integrity": "sha512-yZaiJBbcKR1rSLhiF9KryAFH7R63po+N/invr2EAHGXxMzZksE5j1zyQKvrYiqK47ZHLAlCR+re/PHqWp/UzTg==",
+      "dev": true,
+      "requires": {
+        "@volar/vue-language-core": "1.0.16",
+        "@volar/vue-typescript": "1.0.16"
       }
     },
     "vueuc": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "nuxt prepare",
     "generate": "nuxt generate",
     "preview": "DATABASE_URL=file:./db.sqlite nuxt preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "nuxt typecheck"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
@@ -31,11 +31,13 @@
     "nuxt-svgo": "^1.1.0",
     "playwright": "^1.28.1",
     "prisma": "^4.7.1",
+    "typescript": "^4.9.4",
     "unplugin-auto-import": "^0.12.1",
     "unplugin-vue-components": "^0.22.12",
     "uuid": "^9.0.0",
     "vite-svg-loader": "^3.6.0",
-    "vitest": "^0.25.7"
+    "vitest": "^0.25.7",
+    "vue-tsc": "^1.0.16"
   },
   "dependencies": {
     "@prisma/client": "^4.7.1",


### PR DESCRIPTION
This PR replaces `tsc` with and `nuxt typecheck`.
Using `nuxi typecheck` ensures that types are generated before type-checking. This PR also adds local typescript version and `vue-tsc` base on [nuxt recommendation](https://nuxt.com/docs/api/commands/typecheck)