### PR TITLE
feat: bump sidebase/core to remove sub-dependency on naive-ui

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,7 +1,5 @@
 <template>
   <div>
-    <TheWelcomeContainer>
-      <NTimeline><NTimelineItem /></NTimeline>
-    </TheWelcomeContainer>
+    <TheWelcomeContainer />
   </div>
 </template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "^4.7.1",
-        "@sidebase/core": "^0.1.3",
+        "@sidebase/core": "^0.1.4",
         "@sidebase/nuxt-prisma": "^0.1.0"
       },
       "devDependencies": {
@@ -1594,9 +1594,9 @@
       }
     },
     "node_modules/@sidebase/core": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@sidebase/core/-/core-0.1.3.tgz",
-      "integrity": "sha512-qaiqE5SwgT6ri2JLB2iS0GXPDfYa447noDvJhwAIY0oSJsf3n+tb+8XPUsmT36pxaXWwSLPEKT64PzWDA/7MoA=="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@sidebase/core/-/core-0.1.4.tgz",
+      "integrity": "sha512-uPQfFgVYOuyBGvqp6un5xTbCD7kxPcWuxuHUGIMJZ+Mz9Af6jjcs0ryPRMre/89MAf+gKxV1srxvCudZz5396A=="
     },
     "node_modules/@sidebase/nuxt-prisma": {
       "version": "0.1.0",
@@ -15645,9 +15645,9 @@
       }
     },
     "@sidebase/core": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@sidebase/core/-/core-0.1.3.tgz",
-      "integrity": "sha512-qaiqE5SwgT6ri2JLB2iS0GXPDfYa447noDvJhwAIY0oSJsf3n+tb+8XPUsmT36pxaXWwSLPEKT64PzWDA/7MoA=="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@sidebase/core/-/core-0.1.4.tgz",
+      "integrity": "sha512-uPQfFgVYOuyBGvqp6un5xTbCD7kxPcWuxuHUGIMJZ+Mz9Af6jjcs0ryPRMre/89MAf+gKxV1srxvCudZz5396A=="
     },
     "@sidebase/nuxt-prisma": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@prisma/client": "^4.7.1",
-    "@sidebase/core": "^0.1.3",
+    "@sidebase/core": "^0.1.4",
     "@sidebase/nuxt-prisma": "^0.1.0"
   }
 }


### PR DESCRIPTION
Contributes to https://github.com/sidebase/sidebase/discussions/86

This PR bumps `sidebase/core` to v0.1.4 -> this removes it's dependence on naive UI (only custyom CSS) used, so removing naive UI should be much easier now.

Thanks @thewotan for pushing this suggestion.