### PR TITLE
feat: do not generate vue shims for volar takeover mode conformance

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,5 +7,8 @@ export default defineNuxtConfig({
     version: '0.0.1'
   },
   modules: ['@nuxtjs/tailwindcss', 'nuxt-svgo', '@huntersofbook/naive-ui-nuxt'],
-  extends: ['@sidebase/core', '@sidebase/nuxt-prisma']
+  extends: ['@sidebase/core', '@sidebase/nuxt-prisma'],
+  typescript: {
+    shim: false
+  }
 })


### PR DESCRIPTION
This PR disables `shims` generation. This is a required step for the takeover mode we recommend people to use: https://nuxt.com/docs/getting-started/installation#prerequisites