### PR TITLE
fix: do not use slim version as it causes problems for prisma

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM dependency-base AS production-base
 COPY . .
 RUN npm run build
 
-FROM $NODE_VERSION-slim AS production
+FROM $NODE_VERSION AS production
 
 COPY --from=production-base /app/.output /app/.output
 


### PR DESCRIPTION
Closes #81.

Problem is that `Prisma` does not work with `node-slim` images, at least not for v16:
```
Unknown PRISMA_QUERY_ENGINE_LIBRARY linux-arm64-openssl-undefined. Possible binaryTargets: darwin, darwin-arm64, debian-openssl-1.0.x, debian-openssl-1.1.x, debian-openssl-3.0.x, rhel-openssl-1.0.x, rhel-openssl-1.1.x, rhel-openssl-3.0.x, linux-arm64-openssl-1.1.x, linux-arm64-openssl-1.0.x, linux-arm64-openssl-3.0.x, linux-arm-openssl-1.1.x, linux-arm-openssl-1.0.x, linux-arm-openssl-3.0.x, linux-musl, linux-musl-openssl-3.0.x, linux-nixos, windows, freebsd11, freebsd12, freebsd13, openbsd, netbsd, arm, native or a path to the query engine library.
You may have to run prisma generate for your changes to take effect.
    at RequestHandler.handleRequestError (/app/.output/server/node_modules/@prisma/client/runtime/index.js:35038:13)
    at RequestHandler.handleAndLogRequestError (/app/.output/server/node_modules/@prisma/client/runtime/index.js:34996:12)
    at /app/.output/server/node_modules/@prisma/client/runtime/index.js:35542:25
    at async Proxy._executeRequest (/app/.output/server/node_modules/@prisma/client/runtime/index.js:36111:22)
    at async Proxy._request (/app/.output/server/node_modules/@prisma/client/runtime/index.js:36082:16)
    at async file:///app/.output/server/chunks/healthz.get.mjs:27:5
    at async Object.handler (file:///app/.output/server/node_modules/h3/dist/index.mjs:723:19)
    at async Server.toNodeHandle (file:///app/.output/server/node_modules/h3/dist/index.mjs:798:7) {
  clientVersion: '4.8.0',
  errorCode: undefined
}
```

To resolve this, we just removed the `-slim` from the production stage. This will result in larger docker images, but better larger than not working.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
