### PR TITLE
feat: add env file with default database url (sqlite file)

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=file:./db.sqlite


### PR DESCRIPTION
After init a sidebase project, we can't init the db with `npx prisma db push` because theres no .env file defining the db url.

Contribution # .
